### PR TITLE
ASDPLNG-105: Add puppet-profile_selinux to tag v0.1.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,6 +22,7 @@ mod 'ncsa/profile_motd', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-pro
 mod 'ncsa/profile_pam_access', tag: 'v0.0.5', git: 'https://github.com/ncsa/puppet-profile_pam_access'
 mod 'ncsa/profile_puppet_agent', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'
 mod 'ncsa/profile_puppet_master', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
+mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'
 mod 'ncsa/profile_sudo', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_sudo'
 mod 'ncsa/profile_system_auth', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_system_auth'
 mod 'ncsa/profile_timezone', tag: 'v0.2.1', git: 'https://github.com/ncsa/puppet-profile_timezone'

--- a/site-modules/profile/manifests/base.pp
+++ b/site-modules/profile/manifests/base.pp
@@ -13,6 +13,7 @@ class profile::base {
   include ::profile_puppet_agent
   include ::profile_sudo
   include ::profile_timezone
+  include ::profile_selinux
   include ::profile_system_auth
   include ::profile_virtual
   include ::sshd


### PR DESCRIPTION
This is being tested on glick-pup & glick-client01.

A duplicate of this PR was approved yesterday before this repo was rebuilt today. But thought I'd go through the PR motions to test the new repo configuration.