### PR TITLE
ASDPLNG-117 Edit ignores for POSTROUTING:nat:IPv4

### DIFF
--- a/data/role/puppet_master.yaml
+++ b/data/role/puppet_master.yaml
@@ -7,7 +7,12 @@ profile_firewall::ignores:
   FORWARD:filter:IPv4: ["docker", "DOCKER", "-o"]
   DOCKER:nat:IPv4: "*"
   PREROUTING:nat:IPv4: "-m addrtype --dst-type LOCAL -j DOCKER"
-  POSTROUTING:nat:IPv4: ["172.17", "172.18", "172.19"]
+
+  # Ignores take a regular expression, so escape the . for a literal period
+  POSTROUTING:nat:IPv4:
+    - '-s 172\.'  # yamllint disable-line rule:quoted-strings
+    - '-d 172\.'  # yamllint disable-line rule:quoted-strings
+
   OUTPUT:nat:IPv4: "-d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER"
 
 profile_firewall::purge_all: false


### PR DESCRIPTION
Rules in POSTROUTING:nat:IPv4 on LSST puppet server were getting
removed causing the container to lose network access.

The current list of ignores for that table+chain are not generic enough.
It will ignore rules that match "172.17", "172.18", "172.19"
but LSST was getting rules with 172.21, and there is no immediate
knowledge of why or how docker chooses these addresses

So need to loosen the matching so it will ignore any rule that matches
any of these regexes:

  POSTROUTING:nat:IPv4:
    - '-s 172\.'  # yamllint disable-line rule:quoted-strings
    - '-d 172\.'  # yamllint disable-line rule:quoted-strings

Need to add the string in single quotes otherwise puppet will complain
as it tries to interpret the escape character and you get an error.
Our .yamllint.yaml sets strings to use double-quotes, so use an in-line
flag to turn off that check, otherwise would get a yamllint error