### PR TITLE
Update profile_system_auth to tag v0.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -23,7 +23,7 @@ mod 'ncsa/profile_puppet_agent', tag: 'v0.1.1', git: 'https://github.com/ncsa/pu
 mod 'ncsa/profile_puppet_master', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
 mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'
 mod 'ncsa/profile_sudo', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_sudo'
-mod 'ncsa/profile_system_auth', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_system_auth'
+mod 'ncsa/profile_system_auth', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_system_auth'
 mod 'ncsa/profile_timesync', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_timesync'
 mod 'ncsa/profile_timezone', tag: 'v0.2.1', git: 'https://github.com/ncsa/puppet-profile_timezone'
 mod 'ncsa/profile_virtual', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_virtual'


### PR DESCRIPTION
profile_system_auth tag v0.2.0 switches to use `authselect` instead of `authconfig` as default for RedHat systems