### PR TITLE
SVC-3960: Fix Puppet agent monitoring

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,7 @@ mod 'ncsa/profile_firewall', tag: 'v1.0.5', git: 'https://github.com/ncsa/puppet
 mod 'ncsa/profile_monitoring', tag: 'v0.1.6', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.5', git: 'https://github.com/ncsa/puppet-profile_pam_access'
-mod 'ncsa/profile_puppet_agent', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'
+mod 'ncsa/profile_puppet_agent', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'
 mod 'ncsa/profile_puppet_master', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
 mod 'ncsa/profile_rsyslog', tag: 'v0.1.4', git: 'https://github.com/ncsa/puppet-profile_rsyslog'
 mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -450,9 +450,8 @@ telegraf::inputs:
       - "e*"
       - "bond*"
   processes: [{}]
-  # NEED TO FIX telegraf ACCESS TO PUPPET REPORTS
-  #puppetagent:
-  #  location: "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
+  puppetagent:
+    location: "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
   swap: [{}]
   system: [{}]
   systemd_units:


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVC-3960

This was tested on the following hosts:
- glick-client01

This is mainly to merge over the changes from https://git.ncsa.illinois.edu/ici/asd/asd-pup-control/-/merge_requests/31 