### PR TITLE
ASDPLNG-152: Add ncsa/rhsm module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -30,6 +30,7 @@ mod 'ncsa/profile_update_os', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppe
 mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_virtual'
 mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.1', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
+mod 'ncsa/rhsm', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-rhsm'
 mod 'ncsa/sshd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.1', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -174,6 +174,10 @@ profile_sudo::groups:
 profile_update_os::kernel_upgrade::enabled: false
 profile_update_os::yum_upgrade::enabled: false
 
+# SET THESE PARAMTERS BASED ON RHSM LICENSING
+#rhsm::org: ""
+#rhsm::activationkey: ""
+
 sssd::debug_level: 0
 sssd::domains:
   ncsa.illinois.edu:

--- a/site-modules/profile/manifests/redhat.pp
+++ b/site-modules/profile/manifests/redhat.pp
@@ -1,6 +1,14 @@
 # Place to include any modules that are needed only on RedHat systems
 class profile::redhat {
 
+  # Include some modules based off specific operatingsystem distro (RHEL vs CentOS etc)
+  case $facts['operatingsystem'] {
+    'RedHat' : {
+      include ::rhsm
+    }
+    default  : { } # do nothing
+  }
+
   include ::yum
 
 }


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/ASDPLNG-152

This is being tested on:
- `glick-client01`

Note that because we are not setting the `rhsm` parameters, we get the following output on each puppet run:
> Notice: Missing org value
> Notice: /Stage[main]/Rhsm/Notify[Missing org value]/message: defined 'message' as 'Missing org value'

...which is fine -- it reminds a real control repo to get it setup.