### PR TITLE
SVC-4463: Update ncsa/sssd to tag v3.0.2

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,7 +33,7 @@ mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_xcat', tag: 'v1.1.4', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
 mod 'ncsa/rhsm', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-rhsm'
 mod 'ncsa/sshd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-sshd'
-mod 'ncsa/sssd', tag: 'v3.0.1', git: 'https://github.com/ncsa/puppet-sssd'
+mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'
 mod 'puppet/chrony', '1.0.0'
 mod 'puppet/epel', '3.0.1'


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVC-4463

Fixes https://github.com/ncsa/puppet-sssd/issues/3

This is being tested on:
- `glick-client01`