### PR TITLE
Update for puppet-profile_monitoring v0.1.8

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -15,7 +15,7 @@ mod 'ncsa/profile_audit', tag: 'v0.1.7', git: 'https://github.com/ncsa/puppet-pr
 mod 'ncsa/profile_dns_cache', tag: 'v1.1.2', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
 mod 'ncsa/profile_email', tag: 'v0.2.2', git: 'https://github.com/ncsa/puppet-profile_email'
 mod 'ncsa/profile_firewall', tag: 'v1.0.6', git: 'https://github.com/ncsa/puppet-profile_firewall'
-mod 'ncsa/profile_monitoring', tag: 'v0.1.7', git: 'https://github.com/ncsa/puppet-profile_monitoring'
+mod 'ncsa/profile_monitoring', tag: 'v0.1.8', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_nfs_client', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.5', git: 'https://github.com/ncsa/puppet-profile_pam_access'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -161,12 +161,23 @@ profile_monitoring::telegraf::outputs:
       urls:
         - "https://ncsa-influxdb.ncsa.illinois.edu:8086"
 
+profile_pam_access::allow_rules:
+  "Allow telegraf for inventory script":
+    group: "telegraf"
+    origin: "LOCAL"
+
 profile_sudo::configs:
   common_disabled_users:
     priority: 1
     content:
       - "#deny former NCSA users"
       - "%all_disabled_usr ALL=(ALL) !ALL"
+  telegraf:
+    content:
+      - "#Allow telegraf to collect HW inventory data"
+      - "Defaults:telegraf !requiretty"
+      - "telegraf ALL = NOPASSWD: /usr/sbin/dmidecode"
+      - "telegraf ALL = NOPASSWD: /usr/bin/cat /sys/devices/virtual/dmi/id/product_uuid"
 profile_sudo::groups:
   org_asd: "ALL=(ALL) NOPASSWD: ALL"
   org_irst: "ALL=(ALL) NOPASSWD: ALL"


### PR DESCRIPTION
Updating the puppet-profile_monitoring module to v0.1.8 to add
management support of the inventory collection script

Also updating these configs in data/common.yaml to allow the telegraf
user the permissions to run the HW inventory script:
profile_pam_access::allow_rules:
profile_sudo::configs: