### PR TITLE
ASDPLNG-278: Update ncsa/sshd to tag v0.3.4

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -32,7 +32,7 @@ mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.5', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
 mod 'ncsa/rhsm', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-rhsm'
-mod 'ncsa/sshd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-sshd'
+mod 'ncsa/sshd', tag: 'v0.3.4', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'
 mod 'puppet/chrony', '1.0.0'


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/ASDPLNG-278

Summary:
- Include default setting for `RevokeKeys` in `sshd_config`
- Add comment to top of `sshd_config` about it being managed by Puppet

This is being tested on the following hosts:
- `control-pup01`
- `control-test01`