### PR TITLE
ASDPLNG-323: Update ncsa/rhsm to tag v0.1.3

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -30,7 +30,7 @@ mod 'ncsa/profile_update_os', tag: 'v0.3.6', git: 'https://github.com/ncsa/puppe
 mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_virtual'
 mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.5', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
-mod 'ncsa/rhsm', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-rhsm'
+mod 'ncsa/rhsm', tag: 'v0.1.3', git: 'https://github.com/ncsa/puppet-rhsm'
 mod 'ncsa/sshd', tag: 'v0.3.4', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'


### PR DESCRIPTION
See:
- https://jira.ncsa.illinois.edu/browse/ASDPLNG-323
- https://github.com/ncsa/puppet-rhsm/issues/2

This was tested on `control-pup01` & `control-test01`.