### PR TITLE
ASDPLNG-625 - allow access to default IPv6 localhost

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -15,7 +15,7 @@ mod 'ncsa/profile_audit', tag: 'v0.1.8', git: 'https://github.com/ncsa/puppet-pr
 mod 'ncsa/profile_dns_cache', tag: 'v1.1.2', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
 mod 'ncsa/profile_duo', tag: 'v1.0.2', git: 'https://github.com/ncsa/puppet-profile_duo'
 mod 'ncsa/profile_email', tag: 'v0.2.2', git: 'https://github.com/ncsa/puppet-profile_email'
-mod 'ncsa/profile_firewall', tag: 'v1.0.6', git: 'https://github.com/ncsa/puppet-profile_firewall'
+mod 'ncsa/profile_firewall', tag: 'v1.0.7', git: 'https://github.com/ncsa/puppet-profile_firewall'
 mod 'ncsa/profile_hardening', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_hardening'
 mod 'ncsa/profile_monitoring', tag: 'v0.1.9', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_motd'


### PR DESCRIPTION
Point profile_firewall to branch: rundall/ASDPLNG-625/allow_lo_ipv6. Will update to tag once that branch is merged.