### PR TITLE
SECURITY-1421 Set "AuthenticationMethods none" in global sshd_config

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -35,7 +35,7 @@ mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.6', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
 mod 'ncsa/rhsm', tag: 'v0.1.5', git: 'https://github.com/ncsa/puppet-rhsm'
-mod 'ncsa/sshd', tag: 'v0.3.6', git: 'https://github.com/ncsa/puppet-sshd'
+mod 'ncsa/sshd', tag: 'v0.3.8', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'
 mod 'puppet/chrony', '1.0.0'


### PR DESCRIPTION
NOTICE!
If you are using any of the following modules, make sure you are using
at least this tag version listed:
puppet-profile_allow_ssh_from_bastion v0.2.4
puppet-profile_hostbased_ssh v1.0.1

That is because those modules at that version explicitly set the
AuthenticationMethods xxx for the match blocks that they manage

If you have any other match blocks set via some other means be
sure they also set AuthenticationMethods appropriately, since
this update sets 'AuthenticationMethods none' globally each match
block needs to define what AuthenticationMethods it needs