### PR TITLE
SVC-20629: Upgrade ncsa/profile_motd to tag v0.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,7 @@ mod 'ncsa/profile_email', tag: 'v0.2.2', git: 'https://github.com/ncsa/puppet-pr
 mod 'ncsa/profile_firewall', tag: 'v1.0.7', git: 'https://github.com/ncsa/puppet-profile_firewall'
 mod 'ncsa/profile_hardening', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_hardening'
 mod 'ncsa/profile_monitoring', tag: 'v0.1.9', git: 'https://github.com/ncsa/puppet-profile_monitoring'
-mod 'ncsa/profile_motd', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_motd'
+mod 'ncsa/profile_motd', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_nfs_client', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.6', git: 'https://github.com/ncsa/puppet-profile_pam_access'
 mod 'ncsa/profile_puppet_agent', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'


### PR DESCRIPTION
See: https://jira.ncsa.illinois.edu/browse/SVC-20629

This is being tested on `control-test05` & `control-test06`.