### PR TITLE
SVCPLAN-1236: Update site private to use http protocol for yum proxy

### DIFF
--- a/data/site/private.yaml
+++ b/data/site/private.yaml
@@ -4,4 +4,4 @@ rhsm::proxy::port: "3128"
 
 yum::config_options:
   installonly_limit: 2
-  proxy: "httpproxy.ncsa.illinois.edu:3128"
+  proxy: "http://httpproxy.ncsa.illinois.edu:3128"


### PR DESCRIPTION
Fix #87 

See https://jira.ncsa.illinois.edu/browse/SVCPLAN-1236

This is being tested on `control-test-centos7a` & `control-test06` (RHEL 8.6).