### PR TITLE
SVCPLAN-1107: ignore tracefs in telegraf's inputs.disk

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -458,6 +458,7 @@ telegraf::inputs:
       - "nfs"
       - "nfs4"
       - "tmpfs"
+      - "tracefs"
   io: [{}]
   # NEED TO ADD ipmi_sensor FOR PHYSICAL NODES
   #ipmi_sensor:


### PR DESCRIPTION
[RHEL8+ incorporated tracefs for tracing](https://access.redhat.com/solutions/5914171). We want the `control-repo` default to exclude `tracefs`