### PR TITLE
SVCPLAN-1556 - telegraf input use inputs.diskio instead of inputs.io

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -459,7 +459,10 @@ telegraf::inputs:
       - "nfs4"
       - "tmpfs"
       - "tracefs"
-  io: [{}]
+  diskio:
+    devices:
+      - "sd*"
+      - "vd*"
   # NEED TO ADD ipmi_sensor FOR PHYSICAL NODES
   #ipmi_sensor:
   #  path: "/usr/bin/ipmitool"


### PR DESCRIPTION
inputs.io was deprecated in telegraf version 0.10.0 and will be removed in 2.0.0

The measurement on influxdb side was already named diskio so no changes needed on
grafana panels

Also setup diskio to only monitor certain devices:
sd* and vd*
ignoring devices like: dm-0, loop*, etc