### PR TITLE
SVCPLAN-1587 Update puppet-rhsm from v0.1.6 to v0.1.7

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -35,7 +35,7 @@ mod 'ncsa/profile_user_environment', tag: 'v0.1.0', git: 'https://github.com/ncs
 mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_virtual'
 mod 'ncsa/profile_website', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.7', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
-mod 'ncsa/rhsm', tag: 'v0.1.6', git: 'https://github.com/ncsa/puppet-rhsm'
+mod 'ncsa/rhsm', tag: 'v0.1.7', git: 'https://github.com/ncsa/puppet-rhsm'
 mod 'ncsa/sshd', tag: 'v0.3.8', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'v3.1.2', git: 'https://github.com/ncsa/puppet-telegraf.git'


### PR DESCRIPTION
Fix fact 'rhsm_manage_repo' for Centos hosts