### PR TITLE
SVCPLAN-1649 Set Puppet Class relationships

### DIFF
--- a/site-modules/profile/manifests/base.pp
+++ b/site-modules/profile/manifests/base.pp
@@ -1,6 +1,14 @@
 # Include basic profile classes
 class profile::base {
 
+  # Include some modules based off osfamily
+  case $facts['osfamily'] {
+    'Redhat' : {
+      include ::profile::redhat
+    }
+    default  : { } # do nothing
+  }
+
   include ::augeasproviders::instances
   include ::profile_additional_packages
   include ::profile_allow_ssh_from_bastion
@@ -25,13 +33,5 @@ class profile::base {
   include ::profile_virtual
   include ::profile_xcat::client
   include ::sshd
-
-  # Include some modules based off osfamily
-  case $facts['osfamily'] {
-    'Redhat' : {
-      include ::profile::redhat
-    }
-    default  : { } # do nothing
-  }
 
 }

--- a/site-modules/profile/manifests/redhat.pp
+++ b/site-modules/profile/manifests/redhat.pp
@@ -5,8 +5,11 @@ class profile::redhat {
   case $facts['operatingsystem'] {
     'RedHat' : {
       include ::rhsm
+      Class['profile::redhat'] -> Class['rhsm'] -> Class['yum'] -> Class['profile_additional_packages']
     }
-    default  : { } # do nothing
+    default  : {
+      Class['profile::redhat'] -> Class['yum'] -> Class['profile_additional_packages']
+    }
   }
 
   include ::yum


### PR DESCRIPTION
Takes the Puppet class re-ordering work Bill setup in Holli and moves
that into the redhat.pp profile

The re-ordering work speeds up Puppet runs so that yum repos and packages
are setup before other classes that depend on them try and fail due to
missing dependencies

Moving this logic into redhat.pp doesn't change the behavior, just
moves it to a location specific for RHEL family hosts