### PR TITLE
SECURITY-1502 Update profile_dns_cache to v1.1.3

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -15,7 +15,7 @@ mod 'ncsa/profile_acctd', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-pr
 mod 'ncsa/profile_additional_packages', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppet-profile_additional_packages'
 mod 'ncsa/profile_allow_ssh_from_bastion', tag: 'v0.2.4', git: 'https://github.com/ncsa/puppet-profile_allow_ssh_from_bastion'
 mod 'ncsa/profile_audit', tag: 'v0.1.11', git: 'https://github.com/ncsa/puppet-profile_audit'
-mod 'ncsa/profile_dns_cache', tag: 'v1.1.2', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
+mod 'ncsa/profile_dns_cache', tag: 'v1.1.3', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
 mod 'ncsa/profile_duo', tag: 'v1.0.4', git: 'https://github.com/ncsa/puppet-profile_duo'
 mod 'ncsa/profile_email', tag: 'v0.2.3', git: 'https://github.com/ncsa/puppet-profile_email'
 mod 'ncsa/profile_firewall', tag: 'v1.0.7', git: 'https://github.com/ncsa/puppet-profile_firewall'


### PR DESCRIPTION
This adds an optional method to disable some unbound settings related to DNSSEC

As-is does not change default behavior