### PR TITLE
SVCPLAN-1695: update profile_slurm

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -36,7 +36,7 @@ mod 'ncsa/profile_puppet_agent', tag: 'v0.1.3', git: 'https://github.com/ncsa/pu
 mod 'ncsa/profile_puppet_master', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
 mod 'ncsa/profile_rsyslog', tag: 'v0.1.4', git: 'https://github.com/ncsa/puppet-profile_rsyslog'
 mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'
-mod 'ncsa/profile_slurm', tag: 'v1.1.6', git: 'https://github.com/ncsa/puppet-profile_slurm.git'
+mod 'ncsa/profile_slurm', tag: 'v1.2.0', git: 'https://github.com/ncsa/puppet-profile_slurm.git'
 mod 'ncsa/profile_sudo', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_sudo'
 mod 'ncsa/profile_system_auth', tag: 'v0.3.9', git: 'https://github.com/ncsa/puppet-profile_system_auth'
 mod 'ncsa/profile_timesync', tag: 'v0.2.1', git: 'https://github.com/ncsa/puppet-profile_timesync'


### PR DESCRIPTION
use profile_slurm v1.2.0

1.1.6 -> 1.1.7 — tested on HOLL-I
1.1.7 -> 1.2.0 — tested (profile_slurm::crons, the only thing that changed from 1.1.7 to 1.2.0) on control-test-rhel84b.internal.ncsa.edu