### PR TITLE
SVCPLAN-629: improve tidy class

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,7 +33,7 @@ mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_nfs_client', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.6', git: 'https://github.com/ncsa/puppet-profile_pam_access'
 mod 'ncsa/profile_puppet_agent', tag: 'v0.1.3', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'
-mod 'ncsa/profile_puppet_master', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
+mod 'ncsa/profile_puppet_master', tag: 'v0.1.5', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
 mod 'ncsa/profile_rsyslog', tag: 'v0.1.4', git: 'https://github.com/ncsa/puppet-profile_rsyslog'
 mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'
 mod 'ncsa/profile_slurm', tag: 'v1.2.0', git: 'https://github.com/ncsa/puppet-profile_slurm.git'


### PR DESCRIPTION
Instead of using tidy resource, create a cron that deletes old reports.

Have tested on control-pup01 for a while, also dt-conf01 (not the Puppet part here, but had manually implemented the cron a while ago).