### PR TITLE
SVC-22397: Update ncsa/profile_duo to tag v1.0.5

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -16,7 +16,7 @@ mod 'ncsa/profile_additional_packages', tag: 'v0.3.1', git: 'https://github.com/
 mod 'ncsa/profile_allow_ssh_from_bastion', tag: 'v0.2.4', git: 'https://github.com/ncsa/puppet-profile_allow_ssh_from_bastion'
 mod 'ncsa/profile_audit', tag: 'v0.1.12', git: 'https://github.com/ncsa/puppet-profile_audit'
 mod 'ncsa/profile_dns_cache', tag: 'v1.1.3', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
-mod 'ncsa/profile_duo', tag: 'v1.0.4', git: 'https://github.com/ncsa/puppet-profile_duo'
+mod 'ncsa/profile_duo', tag: 'v1.0.5', git: 'https://github.com/ncsa/puppet-profile_duo'
 mod 'ncsa/profile_email', tag: 'v0.2.3', git: 'https://github.com/ncsa/puppet-profile_email'
 mod 'ncsa/profile_firewall', tag: 'v1.0.7', git: 'https://github.com/ncsa/puppet-profile_firewall'
 mod 'ncsa/profile_globus', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppet-profile_globus'


### PR DESCRIPTION
This change was tested with `linux-test` in the `asd-control` repo.