### PR TITLE
SVCPLAN-2680: update profile_mysql_server to v0.1.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -29,7 +29,7 @@ mod 'ncsa/profile_lustre', tag: 'v1.4.3',  git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
 mod 'ncsa/profile_monitoring', tag: 'v0.1.9', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_motd'
-mod 'ncsa/profile_mysql_server', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
+mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'
 mod 'ncsa/profile_nfs_client', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.6', git: 'https://github.com/ncsa/puppet-profile_pam_access'


### PR DESCRIPTION
Tested on mgsched2 via mg-pup01. Also tested that r10k can build the environment on control-pup01, and tested running control-test-rhel84b.internal.ncsa.edu against that environment (although it doesn't use profile_mysql_server).