### PR TITLE
SECURITY-1497: Upgrade ncsa/profile_email to tag v0.2.4

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,7 +17,7 @@ mod 'ncsa/profile_allow_ssh_from_bastion', tag: 'v0.2.4', git: 'https://github.c
 mod 'ncsa/profile_audit', tag: 'v0.1.14', git: 'https://github.com/ncsa/puppet-profile_audit'
 mod 'ncsa/profile_dns_cache', tag: 'v1.1.3', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
 mod 'ncsa/profile_duo', tag: 'v1.0.5', git: 'https://github.com/ncsa/puppet-profile_duo'
-mod 'ncsa/profile_email', tag: 'v0.2.3', git: 'https://github.com/ncsa/puppet-profile_email'
+mod 'ncsa/profile_email', tag: 'v0.2.4', git: 'https://github.com/ncsa/puppet-profile_email'
 mod 'ncsa/profile_firewall', tag: 'v1.0.7', git: 'https://github.com/ncsa/puppet-profile_firewall'
 mod 'ncsa/profile_globus', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppet-profile_globus'
 mod 'ncsa/profile_gpfs_client', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_gpfs_client.git'


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SECURITY-1497

We need to optionally allow hosts within a cluster to relay SMTP traffic.

This was tested on `control-test-rhel8a`.

- `control-test-rhel86a` was temporarily setup to relay through `control-test-rhel8a`.

