### PR TITLE
SVCPLAN-3012: update profile_lustre to v1.4.4

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -26,7 +26,7 @@ mod 'ncsa/profile_hardening', tag: 'v0.4.0', git: 'https://github.com/ncsa/puppe
 mod 'ncsa/profile_hostbased_ssh', tag: 'v1.0.3', git: 'https://github.com/ncsa/puppet-profile_hostbased_ssh'
 mod 'ncsa/profile_java', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_java.git'
 mod 'ncsa/profile_lmod', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_lmod.git'
-mod 'ncsa/profile_lustre', tag: 'v1.4.3',  git: 'https://github.com/ncsa/puppet-profile_lustre'
+mod 'ncsa/profile_lustre', tag: 'v1.4.4',  git: 'https://github.com/ncsa/puppet-profile_lustre'
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
 mod 'ncsa/profile_monitoring', tag: 'v0.1.9', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.3.0', git: 'https://github.com/ncsa/puppet-profile_motd'


### PR DESCRIPTION
This pulls in an update to profile_lustre. Note that the only update there is in the README, although I did make sure that r10k runs on control-pup01 and that a couple of test clients can get a catalog from that environment (and a no-op Puppet run).