### PR TITLE
SVCPLAN-927 Update profile_monitoring from v0.1.9 to v0.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -29,7 +29,7 @@ mod 'ncsa/profile_java', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-pro
 mod 'ncsa/profile_lmod', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_lmod.git'
 mod 'ncsa/profile_lustre', tag: 'v1.4.4',  git: 'https://github.com/ncsa/puppet-profile_lustre'
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
-mod 'ncsa/profile_monitoring', tag: 'v0.1.9', git: 'https://github.com/ncsa/puppet-profile_monitoring'
+mod 'ncsa/profile_monitoring', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.3.0', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -484,11 +484,6 @@ telegraf::inputs:
     devices:
       - "sd*"
       - "vd*"
-  # NEED TO ADD ipmi_sensor FOR PHYSICAL NODES
-  #ipmi_sensor:
-  #  path: "/usr/bin/ipmitool"
-  #  interval: "60s"
-  #  timeout: "10s"
   mem: [{}]
   net:
     interfaces:


### PR DESCRIPTION
This updated module will automatically add the telegraf ipmi_sensor plugin on hardware nodes. So if you already define ipmi_sensor by adding it to telegraf::inputs:ipmi_sensor you should remove it. Otherwise it will be defined in two places which won't break anything but will confuse people