### PR TITLE
SVCPLAN-2290 Update puppet-profile_audit from v0.1.15 to v0.1.16

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -15,7 +15,7 @@ mod 'ncsa/pam_access', tag: 'ncsa/1.1.0', git: 'https://github.com/ncsa/puppet-p
 mod 'ncsa/profile_acctd', tag: 'v1.2.1', git: 'https://github.com/ncsa/puppet-profile_acctd'
 mod 'ncsa/profile_additional_packages', tag: 'v0.4.1', git: 'https://github.com/ncsa/puppet-profile_additional_packages'
 mod 'ncsa/profile_allow_ssh_from_bastion', tag: 'v0.2.4', git: 'https://github.com/ncsa/puppet-profile_allow_ssh_from_bastion'
-mod 'ncsa/profile_audit', tag: 'v0.1.15', git: 'https://github.com/ncsa/puppet-profile_audit'
+mod 'ncsa/profile_audit', tag: 'v0.1.16', git: 'https://github.com/ncsa/puppet-profile_audit'
 mod 'ncsa/profile_backup', tag: 'v0.0.7', git: 'https://github.com/ncsa/puppet-profile_backup'
 mod 'ncsa/profile_dns_cache', tag: 'v1.1.3', git: 'https://github.com/ncsa/puppet-profile_dns_cache'
 mod 'ncsa/profile_duo', tag: 'v1.0.5', git: 'https://github.com/ncsa/puppet-profile_duo'


### PR DESCRIPTION
See commit notes in module since some hosts may need manual cleanup