### PR TITLE
SVCPLAN-2993 Update puppet-sshd from v0.4.1 to v0.5.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -51,7 +51,7 @@ mod 'ncsa/profile_virtual', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-
 mod 'ncsa/profile_website', tag: 'v0.1.6', git: 'https://github.com/ncsa/puppet-profile_website'
 mod 'ncsa/profile_xcat', tag: 'v1.1.7', git: 'https://github.com/ncsa/puppet-profile_xcat.git'
 mod 'ncsa/rhsm', tag: 'v0.1.7', git: 'https://github.com/ncsa/puppet-rhsm'
-mod 'ncsa/sshd', tag: 'v0.4.1', git: 'https://github.com/ncsa/puppet-sshd'
+mod 'ncsa/sshd', tag: 'v0.5.0', git: 'https://github.com/ncsa/puppet-sshd'
 mod 'ncsa/sssd', tag: 'v3.0.2', git: 'https://github.com/ncsa/puppet-sssd'
 mod 'ncsa/telegraf', tag: 'ncsa/v0.1.1', git: 'https://github.com/ncsa/puppet-telegraf.git'
 mod 'puppet/chrony', '1.0.0'


### PR DESCRIPTION
See commit message in module for some possible cleanup tasks