### PR TITLE
SVCPLAN-2686: update profile_slurm_to_v1.5.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -40,7 +40,7 @@ mod 'ncsa/profile_puppet_agent', tag: 'v0.1.3', git: 'https://github.com/ncsa/pu
 mod 'ncsa/profile_puppet_master', tag: 'v0.1.5', git: 'https://github.com/ncsa/puppet-profile_puppet_master'
 mod 'ncsa/profile_rsyslog', tag: 'v0.1.4', git: 'https://github.com/ncsa/puppet-profile_rsyslog'
 mod 'ncsa/profile_selinux', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_selinux'
-mod 'ncsa/profile_slurm', tag: 'v1.5.0', git: 'https://github.com/ncsa/puppet-profile_slurm.git'
+mod 'ncsa/profile_slurm', tag: 'v1.5.1', git: 'https://github.com/ncsa/puppet-profile_slurm.git'
 mod 'ncsa/profile_sudo', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_sudo'
 mod 'ncsa/profile_system_auth', tag: 'v0.4.0', git: 'https://github.com/ncsa/puppet-profile_system_auth'
 mod 'ncsa/profile_timesync', tag: 'v0.2.1', git: 'https://github.com/ncsa/puppet-profile_timesync'


### PR DESCRIPTION
Tested on MG cluster.

Also tested with control-pup01 + control-test-rhel8b. The latter doesn't include this class, but at least r10k and Puppet run w/o error.