### PR TITLE
SVCPLAN-3996: Upgrade ncsa/motd to tag v0.3.2 - issue9-etcmotdd-broken-for-user-root

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -32,7 +32,7 @@ mod 'ncsa/profile_lmod', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-pro
 mod 'ncsa/profile_lustre', tag: 'v1.4.4',  git: 'https://github.com/ncsa/puppet-profile_lustre'
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
 mod 'ncsa/profile_monitoring', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_monitoring'
-mod 'ncsa/profile_motd', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppet-profile_motd'
+mod 'ncsa/profile_motd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'
 mod 'ncsa/profile_nfs_client', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'


### PR DESCRIPTION
Fixes https://github.com/ncsa/puppet-profile_motd/issues/9

This has been tested extensively in `asd-pup-control`.