### PR TITLE
SVCPLAN-2009: update profile_nfs_client to v0.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -35,7 +35,7 @@ mod 'ncsa/profile_monitoring', tag: 'v0.2.0', git: 'https://github.com/ncsa/pupp
 mod 'ncsa/profile_motd', tag: 'v0.3.1', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'
-mod 'ncsa/profile_nfs_client', tag: 'v0.1.2', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
+mod 'ncsa/profile_nfs_client', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_nfs_client'
 mod 'ncsa/profile_pam_access', tag: 'v0.0.6', git: 'https://github.com/ncsa/puppet-profile_pam_access'
 mod 'ncsa/profile_postgres_server', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_postgres_server'
 mod 'ncsa/profile_puppet_agent', tag: 'v0.1.3', git: 'https://github.com/ncsa/puppet-profile_puppet_agent'


### PR DESCRIPTION
This adds the nfs4-acl-tools to all NFS clients, which allows for viewing and modifying NFSv4 ACLs.