### PR TITLE
SVCPLAN-3972: Unify local telegraf uid

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,7 +31,7 @@ mod 'ncsa/profile_java', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-pro
 mod 'ncsa/profile_lmod', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_lmod.git'
 mod 'ncsa/profile_lustre', tag: 'v1.4.4',  git: 'https://github.com/ncsa/puppet-profile_lustre'
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
-mod 'ncsa/profile_monitoring', tag: 'v0.2.0', git: 'https://github.com/ncsa/puppet-profile_monitoring'
+mod 'ncsa/profile_monitoring', tag: 'v0.2.1', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -449,6 +449,7 @@ sssd::services:
       - "sshd"
       - "sssd"
       - "suiadmin"
+      - "svcicitelegraf"
       - "sync"
       - "systemd-bus-proxy"
       - "systemd-network"


### PR DESCRIPTION
This is being tested in control-repo on the following hosts:

```
control-test-centos7a
control-test-centos7b
control-test-rhel7a
control-test-rhel7b
control-test-rhel8a
control-test-rhel8b
control-test-rhel9a
control-test-rhel9b
```