### PR TITLE
SVCPLAN-4537: fix Hiera param for profile_monitoring::telegraf::input…

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,7 +8,7 @@ lookup_options:
     merge:
       strategy: "deep"
       merge_hash_arrays: true
-  profile_monitoring::telegraf::input_extra_scripts:
+  profile_monitoring::telegraf::inputs_extra_scripts:
     merge:
       strategy: "deep"
       merge_hash_arrays: true


### PR DESCRIPTION
…s_extra_scripts

In common.yaml lookup_options we define data for a param profile_monitoring::telegraf::input_extra_scripts
which should be
profile_monitoring::telegraf::inputs_extra_scripts