### PR TITLE
SVCPLAN-4538: update KNOWN_RO_MOUNTS for telegraf to ignore

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,7 +31,7 @@ mod 'ncsa/profile_java', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-pro
 mod 'ncsa/profile_lmod', tag: 'v0.1.0', git: 'https://github.com/ncsa/puppet-profile_lmod.git'
 mod 'ncsa/profile_lustre', tag: 'v1.4.4',  git: 'https://github.com/ncsa/puppet-profile_lustre'
 mod 'ncsa/profile_lvm', tag: 'v1.0.0',  git: 'https://github.com/ncsa/puppet-profile_lvm'
-mod 'ncsa/profile_monitoring', tag: 'v0.3.0', git: 'https://github.com/ncsa/puppet-profile_monitoring'
+mod 'ncsa/profile_monitoring', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-profile_monitoring'
 mod 'ncsa/profile_motd', tag: 'v0.3.2', git: 'https://github.com/ncsa/puppet-profile_motd'
 mod 'ncsa/profile_mysql_server', tag: 'v0.1.1', git: 'https://github.com/ncsa/puppet-profile_mysql_server'
 mod 'ncsa/profile_network', tag: 'v1.0.0', git: 'https://github.com/ncsa/puppet-profile_network.git'


### PR DESCRIPTION
Update profile_monitoring from v0.3.0 to v0.3.2 so that RO RHEL 9 systemd mounts are included in KNOWN_RO_MOUNTS in mount-state.sh and are ignored.