### PR TITLE
SVCPLAN-5026: module updates for Slurm v23.11 support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -87,5 +87,9 @@ mod 'treydock/apptainer', '2.0.0'
 mod 'treydock/lmod', '3.2.0'
 mod 'treydock/munge', '4.1.0'
 mod 'treydock/nhc', '5.0.0'
-mod 'treydock/slurm', '2.2.0'
-mod 'treydock/slurm_providers', '0.12.3'
+# These versions of treydock/slurm* are updated for Slurm v23.11 support. They should also
+# work for Slurm v22.05 and v23.02 but NCSA has not tested them with those. Consider using
+# the earlier modules versions specified in comments below if still using those earlier
+# versions of Slurm.
+mod 'treydock/slurm', '4.0.1'  # (previously 2.2.0) 
+mod 'treydock/slurm_providers', '0.14.1'  # (previously 0.12.3) 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -217,6 +217,10 @@ profile_update_os::yum_upgrade::enabled: true
 
 profile_xcat::master_node_ip: "172.28.18.18"
 
+# we have not yet tested cgroups-v2 with Slurm, so pin
+# to v1 for now
+slurm::cgroup_plugin: "cgroup/v1"
+
 sssd::debug_level: 0
 sssd::domains:
   ncsa.illinois.edu:


### PR DESCRIPTION
These newer module versions are supposed to work with Slurm v22.05 & v23.02 (in addition to v23.11) but we have not tested with them.

Also pin CgroupPlugin to "cgroup/v1" until we test cgroups-v2.